### PR TITLE
AppiumUtilClassModifiedVersion

### DIFF
--- a/src/test/java/com/yahoo/mobile/AppiumServiceBuilder
+++ b/src/test/java/com/yahoo/mobile/AppiumServiceBuilder
@@ -1,0 +1,82 @@
+package com.mrmoin.appium.appiumproject;
+
+import java.io.File;
+import java.io.IOException;
+import io.appium.java_client.service.local.AppiumServiceBuilder;
+
+public class AppiumUtilClass {
+
+	private static Process p;
+	// private static String fileNameInMPGFormat="";
+	private static String videoDevicePath;
+	// private static String pathInMachineToSaveVideo;
+	private static AppiumServiceBuilder service;
+
+	public static void main(String[] args) {
+		startAppium();
+		try {
+			Thread.sleep(20000);
+		} catch (InterruptedException e1) {
+			e1.printStackTrace();
+		}
+		startVideoCapture("");
+		try {
+			Thread.sleep(15000);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		stopVideoCapture("");
+	}
+
+	public static void startAppium() {
+		System.out.println("Trying to start the Appium Server!");
+
+		service = new AppiumServiceBuilder().usingDriverExecutable(new File("/usr/local/bin/node"))
+				.withAppiumJS(new File("//usr/local/lib/node_modules/appium/build/lib/main.js"))
+				.withLogFile(new File("/Users/Khaja/Documents/workspace/appiumproject/appium-logs"));
+		service.build().stop();
+		service.build().start();
+		try {
+			Thread.sleep(10000);
+		} catch (InterruptedException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		System.out.println("Started Appium Server!");
+	}
+
+	public static void stopAppium() {
+		System.out.println("Trying to stop the Appium Server!");
+		service.build().stop();
+		System.out.println("Stopped the Appium Server!");
+	}
+
+	public static void startVideoCapture(String fileNameInMPGFormat) {
+		System.out.println("Starting the Video Capture");
+		// AppiumUtilClass.fileNameInMPGFormat=fileNameInMPGFormat;
+		AppiumUtilClass.videoDevicePath = "/sdcard/Movies/11.mp4";
+		String cmd1 = "/Users/Khaja/Documents/Appium/android-sdk-macosx/platform-tools/adb shell screenrecord /sdcard/Movies/11.mp4";
+		try {
+			p = Runtime.getRuntime().exec(cmd1);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		System.out.println("End of the startVideoCapture Method!");
+	}
+
+	public static void stopVideoCapture(String pathInMachineToSaveVideo) {
+		// Implement below method
+		// AppiumUtilClass.pathInMachineToSaveVideo=pathInMachineToSaveVideo;
+		p.destroy();
+		try {
+			Thread.sleep(1000);
+			Runtime.getRuntime().exec("/Users/Khaja/Documents/Appium/android-sdk-macosx/platform-tools/adb pull "
+					+ videoDevicePath + " /Users/Khaja/Documents/Appium/android-resources/22.mp4");
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		System.out.println("Stopped the ");
+	}
+}


### PR DESCRIPTION
In this class i have added a new way of starting and stopping the appium server (using AppiumServiceBuilder class) which will work across all platforms that Appium supports. 

Also, if you are using Eclipse and facing this error "cannot run program adb error=2 no such file or directory", when running the standalone adb commands through Eclipse, i have provided a solution through this code. It's not particularly an impressive solution, but a work around or now, until the time i figure out how to make Eclipse drive the ADB available in the my machine. 

When trying to clone and/ or download this class and use, please update the package name, its currently not in sync with this project structure. Please feel free to update it.
